### PR TITLE
adjust linear model parameter

### DIFF
--- a/pyPhenology/models/stat_models.py
+++ b/pyPhenology/models/stat_models.py
@@ -37,16 +37,16 @@ class Linear(BaseModel):
     def __init__(self, parameters={}):
         BaseModel.__init__(self)
         self.all_required_parameters = {'intercept': (-67, 298), 'slope': (-25, 25),
-                                        'spring_start': 0, 'spring_end': 90}
+                                        'spring_start': 0, 'spring_length': 90}
         self._organize_parameters(parameters)
         self._required_data = {'predictor_columns': ['site_id', 'year', 'doy', 'temperature'],
                                'predictors': ['temperature', 'doy_series']}
 
     def _apply_model(self, temperature, doy_series, intercept, slope,
-                     spring_start, spring_end):
+                     spring_start, spring_length):
         mean_spring_temp = utils.transforms.mean_temperature(temperature, doy_series,
                                                              start_doy=spring_start,
-                                                             end_doy=spring_end)
+                                                             end_doy=spring_start + spring_length)
         return mean_spring_temp * slope + intercept
 
 

--- a/pyPhenology/models/stat_models.py
+++ b/pyPhenology/models/stat_models.py
@@ -28,9 +28,9 @@ class Linear(BaseModel):
             | The start day of spring
             | default : 1 (Jan 1)
 
-        spring_end : int
-            | The last day of spring
-            | default : 90 \(March 30\)
+        spring_length : int
+            | The length of spring in days
+            | default : 90
 
     """
 

--- a/test/test_known_parameter_values.py
+++ b/test/test_known_parameter_values.py
@@ -93,7 +93,7 @@ test_cases.append({'test_name' : 'Linear Model Aspen leaves',
                    'model' : models.Linear,
                    'fitting_obs':aspen_leaves,
                    'fitting_temp':aspen_temp,
-                   'expected_params':{'intercept': 113, 'slope': -1, 'spring_start': 0, 'spring_end': 90},
+                   'expected_params':{'intercept': 113, 'slope': -1, 'spring_start': 0, 'spring_length': 90},
                    'fitting_ranges':{},
                    'fitting_params':thorough_DE_optimization})
 


### PR DESCRIPTION
Use a spring start date + spring length instead of
spring start + end date. This will be easier to estimate since
you don't have to enforce the start date being < end date.