### PR TITLE
propagate aggregation for ensemble prediction

### DIFF
--- a/pyPhenology/models/base.py
+++ b/pyPhenology/models/base.py
@@ -94,7 +94,7 @@ class BaseModel():
                  'in model fitting. Perhaps try with different optimizer '\
                  'values.')
 
-    def predict(self, to_predict=None, predictors=None):
+    def predict(self, to_predict=None, predictors=None, **kwargs):
         """Make predictions
 
         Predict the DOY given predictor data and associated site/year info.

--- a/pyPhenology/models/ensemble_models.py
+++ b/pyPhenology/models/ensemble_models.py
@@ -211,7 +211,8 @@ class BootstrapModel(EnsembleBase):
             to_predict = self.observations
 
         predictions = Parallel(n_jobs = n_jobs)(delayed(self._predict_job)
-            (m, to_predict = to_predict, predictors = predictors, **kwargs)
+            (m, to_predict = to_predict, predictors = predictors,
+             aggregation=aggregation, **kwargs)
             for m in self.model_list)
 
         predictions = np.array(predictions)
@@ -357,7 +358,8 @@ class Ensemble(EnsembleBase):
             to_predict = self.observations
 
         predictions = Parallel(n_jobs = n_jobs)(delayed(self._predict_job)
-            (m, to_predict = to_predict, predictors = predictors, **kwargs)
+            (m, to_predict = to_predict, predictors = predictors, 
+             aggregation=aggregation, **kwargs)
             for m in self.model_list)
 
         predictions = np.array(predictions)
@@ -570,7 +572,7 @@ class WeightedEnsemble(EnsembleBase):
                  verbose=verbose, debug=debug) for m in self.model_list)
 
     def predict(self, to_predict=None, predictors=None,
-                aggregation = 'weighted_mean', n_jobs=1, **kwargs):
+                aggregation = 'mean', n_jobs=1, **kwargs):
         """Make predictions..
 
         Predictions will be made using each core models, then a final average
@@ -599,12 +601,13 @@ class WeightedEnsemble(EnsembleBase):
             to_predict = self.observations
 
         predictions = Parallel(n_jobs = n_jobs)(delayed(self._predict_job)
-            (m, to_predict = to_predict, predictors = predictors, **kwargs)
+            (m, to_predict = to_predict, predictors = predictors,
+             aggregation=aggregation, **kwargs)
             for m in self.model_list)
 
         predictions = np.array(predictions)
 
-        if aggregation=='weighted_mean':
+        if aggregation=='mean':
             # Transpose to align the model axis with the 1D weight array
             # then transpose back to sum the weighted predictions.
             return (predictions.T * self.weights).T.sum(0)

--- a/pyPhenology/models/ensemble_models.py
+++ b/pyPhenology/models/ensemble_models.py
@@ -64,6 +64,17 @@ class EnsembleBase():
         """A wrapper to predict new data within joblib.Parallel"""
         return model.predict(to_predict=to_predict, predictors=predictors, **kwargs)
     
+    def ensemble_shape(self, shape=()):
+        """Returns a tuple signifying the layers of submodels
+        ie. for a single 50-bootstrap model the shape is (50,)
+        for an ensemble of four 50-bootstrapped  models the shape is (4,50)
+        """
+        num_sub_models = len(self.model_list)
+        if isinstance(self.model_list[0], EnsembleBase):
+            return self.model_list[0].ensemble_shape(shape = shape + (num_sub_models,))
+        else:
+            return shape + (num_sub_models,)
+    
 class BootstrapModel(EnsembleBase):
     """Fit a model using bootstrapping of the data.
 

--- a/test/test_ensemble_models.py
+++ b/test/test_ensemble_models.py
@@ -100,7 +100,7 @@ def test_ensemble_model_predict_default(model_name, fitted_model):
 @pytest.mark.parametrize('model_name, fitted_model', test_cases_minus_weighted)
 def test_ensemble_model_predict_none_shape(model_name, fitted_model):
     """Predict with aggregation='none' returns a 2d array"""
-    assert len(fitted_model.predict(aggregation='none').shape) == 2
+    assert fitted_model.predict(aggregation='none').shape[:-1] == fitted_model.ensemble_shape()
 
 @pytest.mark.parametrize('model_name, fitted_model', test_cases)
 def test_ensemble_score(model_name, fitted_model):
@@ -149,9 +149,6 @@ def test_ensemble_aggregation(model_name, fitted_model):
 
 ######################
 # More specific tests for the different ensembles
-def test_bootstrap_model_predict_none_length():
-    """Predict with aggregation='none' returns a 2d array"""
-    assert bootstrap_model.predict(aggregation='none').shape[0] == n_bootstraps
 
 def test_WeightedEnsemble_weight_shape():
     """Array of fitted weights should be this shape"""


### PR DESCRIPTION
If I make an ensemble of ensembles the aggregation type
would not be passed to the sub-ensebmels.

ie. An ensemble of 4 models, each of which is a bootstrap of
100 models, using aggregation='none' would return the 4
values, each of which is the mean of the bootstraps.

need **kwargs in base prediction method so it accepts, but
doesn't use, the aggregation arg.